### PR TITLE
Add rust toolchain to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-alpine
 
 RUN apk upgrade
-RUN apk --update add --no-cache openssl-dev libffi-dev py3-pip python3 samba-client samba-common-tools yaml-dev
+RUN apk --update add --no-cache rust cargo openssl-dev libffi-dev py3-pip python3 samba-client samba-common-tools yaml-dev
 RUN apk --update add --virtual build-dependencies build-base git \
   && git clone https://github.com/cddmp/enum4linux-ng.git \
   && pip install -r enum4linux-ng/requirements.txt \


### PR DESCRIPTION
The build failed due to the lack of rustc and cargo as dependencies for the Python cryptography package.

Here is what happened before adding `rust`:
```
#7 37.31   generating cffi module 'build/temp.linux-x86_64-3.8/_openssl.c'
#7 37.31   running build_rust
#7 37.31
#7 37.31       =============================DEBUG ASSISTANCE=============================
#7 37.31       If you are seeing a compilation error please try the following steps to
#7 37.31       successfully install cryptography:
#7 37.31       1) Upgrade to the latest pip and try again. This will fix errors for most
#7 37.31          users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
#7 37.31       2) Read https://cryptography.io/en/latest/installation.html for specific
#7 37.31          instructions for your platform.
#7 37.31       3) Check our frequently asked questions for more information:
#7 37.31          https://cryptography.io/en/latest/faq.html
#7 37.31       4) Ensure you have a recent Rust toolchain installed:
#7 37.31          https://cryptography.io/en/latest/installation.html#rust
#7 37.31       5) If you are experiencing issues with Rust for *this release only* you may
#7 37.31          set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
#7 37.31       =============================DEBUG ASSISTANCE=============================
#7 37.31
#7 37.31   error: can't find Rust compiler
```

Here is what happened before adding `cargo`:
```
#6 35.43   generating cffi module 'build/temp.linux-x86_64-3.8/_openssl.c'
#6 35.43   running build_rust
#6 35.43
#6 35.43       =============================DEBUG ASSISTANCE=============================
#6 35.43       If you are seeing a compilation error please try the following steps to
#6 35.43       successfully install cryptography:
#6 35.43       1) Upgrade to the latest pip and try again. This will fix errors for most
#6 35.43          users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
#6 35.43       2) Read https://cryptography.io/en/latest/installation.html for specific
#6 35.43          instructions for your platform.
#6 35.43       3) Check our frequently asked questions for more information:
#6 35.43          https://cryptography.io/en/latest/faq.html
#6 35.43       4) Ensure you have a recent Rust toolchain installed:
#6 35.43          https://cryptography.io/en/latest/installation.html#rust
#6 35.43       5) If you are experiencing issues with Rust for *this release only* you may
#6 35.43          set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
#6 35.43       =============================DEBUG ASSISTANCE=============================
#6 35.43
#6 35.43   error: [Errno 2] No such file or directory: 'cargo'
```

Here is what happens when I run it now on my own VM:
```
/tmp $ enum4linux-ng 10.10.159.232
ENUM4LINUX - next generation

 ==========================
|    Target Information    |
 ==========================
[*] Target ........... 10.10.159.232
[*] Username ......... ''
[*] Random Username .. 'zsmaabiy'
[*] Password ......... ''
[*] Timeout .......... 5 second(s)

 =====================================
|    Service Scan on 10.10.159.232    |
 =====================================
[*] Checking LDAP
[-] Could not connect to LDAP on 389/tcp: timed out
[*] Checking LDAPS
[-] Could not connect to LDAPS on 636/tcp: timed out
[*] Checking SMB
[-] Could not connect to SMB on 445/tcp: timed out
[*] Checking SMB over NetBIOS
[-] Could not connect to SMB over NetBIOS on 139/tcp: timed out

[!] Aborting remainder of tests since neither SMB nor LDAP are accessible

Completed after 20.04 seconds
```

Edit: Note that I've aliased `enum4linux-ng` so I don't have to run `docker run -t enum4linux-ng`.