### PR TITLE
Update enum4linux-ng.py

### DIFF
--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -2550,7 +2550,7 @@ def warn(msg):
     print("\n"+Colors.yellow(f"[!] {msg}"))
 
 def yamlize(msg, sort=False, rstrip=True):
-    result = yaml.dump(msg, default_flow_style=False, sort_keys=sort, width=160, Dumper=Dumper)
+    result = yaml.dump(msg, default_flow_style=False, sort_keys=True, width=160, Dumper=Dumper)
     if rstrip:
         return result.rstrip()
     return result


### PR DESCRIPTION
Fix a keyword arguments "sort_keys=True" in yaml.dump()


![image](https://user-images.githubusercontent.com/33048622/129042983-bf1bf3f4-ad5c-4c5e-a0a8-b77b6d63e5a7.png)

And I found that in some env the keyword "sort_keys" dose not exist in yaml.dump(), so If meet that Error in the picture, can fix it by just remove the keyword arg "sort_keys". 