### PR TITLE
Remove additional `--update` for `apk` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.8-alpine
 
 RUN apk upgrade
-RUN apk --update add --no-cache rust cargo openssl-dev libffi-dev py3-pip python3 samba-client samba-common-tools yaml-dev
-RUN apk --update add --virtual build-dependencies build-base git \
+RUN apk add --no-cache rust cargo openssl-dev libffi-dev py3-pip python3 samba-client samba-common-tools yaml-dev
+RUN apk add --virtual build-dependencies build-base git \
   && git clone https://github.com/cddmp/enum4linux-ng.git \
   && pip install -r enum4linux-ng/requirements.txt \
   && apk del build-dependencies


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache`, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest and without temporary files remains in the image.