### PR TITLE
Kerberos improvements

### DIFF
--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -545,6 +545,9 @@ class SambaTool():
                 output = output.replace(line, "")
         output = output.rstrip('\n')
 
+        if "Cannot find KDC for realm" in output:
+            return Result(False, "Cannot find KDC for realm, check DNS settings or setup /etc/krb5.conf")
+
         if retval == 1 and not output:
             return Result(False, "empty response")
 

--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -495,7 +495,13 @@ class SambaTool():
                 self.env = os.environ.copy()
                 self.env['KRB5CCNAME'] = self.creds.ticket_file
                 # User and domain are taken from the ticket
-                self.exec += ['-k']
+                # Kerberos options differ between samba versions
+                samba_version = re.match(r".*(\d+\.\d+\.\d+).*", check_output(["smbclient", "--version"]).decode()).group(1)
+                samba_version = tuple(int(x) for x in samba_version.split('.'))
+                if samba_version < (4, 15, 0):
+                    self.exec += ['-k']
+                else:
+                    self.exec += ['--use-krb5-ccache', self.creds.ticket_file]
             elif creds.nthash:
                 self.exec += ['-W', f'{self.creds.domain}']
                 self.exec += ['-U', f'{self.creds.user}%{self.creds.nthash}', '--pw-nt-hash']


### PR DESCRIPTION
This PR fixes the deprecated Kerberos option `-k` for samba tools.

It was producing warning messages and did not work for `rpcclient` at all.
So I changed this to `--use-krb5-ccache` instead, which works with `rpcclient`, too.

Besides, I added a more helpful error message, in case `/etc/krb5.conf` isn't configured.
In order for Kerberos authentication to work in samba tools, one needs to setup `/etc/krb5.conf` manually and fill it with correct KDC settings. If one is not aware of this or forgets it, only a vague error message is shown:

```
[*] Check for Kerberos session
[-] Could not establish Kerberos session: STATUS_LOGON_FAILURE
```

When running smbclient manually an error like the following is shown:

```
gse_get_client_auth_token: gss_init_sec_context failed with [Unspecified GSS failure.  Minor code may provide more information: Cannot find KDC for realm "CONTOSO.LOCAL"](2529639066)
gensec_spnego_client_negTokenInit_step: gse_krb5: creating NEG_TOKEN_INIT for cifs/dc1.contoso.local failed (next[(null)]): NT_STATUS_LOGON_FAILURE
session setup failed: NT_STATUS_LOGON_FAILURE
```

Since it is easy to forget setting up `/etc/krb5.conf`, let's catch the "Cannot find KDC for realm" error and point the user towards the config file.