### PR TITLE
Improves RID Cycling performance (SID lookups batching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I made it for educational purposes for myself and to overcome issues with enum4l
 ## Differences
 Some things are implemented differently compared to the original enum4linux. These are the important differences:
 - RID cycling is not part of the default enumeration (```-A```) but can be enabled with ```-R```
+- RID cycling can be achieved faster, by grouping multiple SID lookups in the same rpcclient call
 - parameter naming is slightly different (e.g. ```-A``` instead of ```-a```)
 
 ## Credits
@@ -97,7 +98,7 @@ options:
   -O                 Get OS information via RPC
   -L                 Get additional domain info via LDAP/LDAPS (for DCs only)
   -I                 Get printer information via RPC
-  -R                 Enumerate users via RID cycling
+  -R                 Enumerate users via RID cycling. Optionally, specifies lookup request size.
   -N                 Do an NetBIOS names lookup (similar to nbtstat) and try to retrieve workgroup from output
   -w DOMAIN          Specify workgroup/domain manually (usually found automatically)
   -u USER            Specify username to use (default "")


### PR DESCRIPTION
Improves performance by **reducing overall overhead** (_mainly rpcclient subprocess spawning and network latency_).
Plus, **decreases the number of requests** made to the server by N times (_where N is the chosen batch size_), potentially producing less noise (_although the server may consider "weird" that rpcclient lookupsids batches all this sid together_).

Below results of testing against an HTB machine, notice the **drastic time improvement**.

**Without Batching:**
`./enum4linux-ng.py -A $TRG -R`
![Screenshot_2022-12-16-16-01-13_1920x2160](https://user-images.githubusercontent.com/84291326/208126655-1cba08e9-fb6c-415d-94fb-5a1b38c70e89.png)

**With Batching**
`./enum4linux-ng.py -A $TRG -R 14`
![Screenshot_2022-12-16-15-50-00_1920x2160](https://user-images.githubusercontent.com/84291326/208126612-4b3e92fb-c20f-4cb4-8ead-992bc74fdf94.png)

EDIT: _just noticed that the last test reported more groups, that's because I did not bother checking the upper bound on end_rid for rid_range, therefore the last batch went beyond the default 550. I though that it would be no harm to "accidentally" include a few more RIDs._ 