### PR TITLE
Bulks lookupnames, adds username bruteforcing from wordlist file, adds progess bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ options:
   -H NTHASH          Try to authenticate with hash
   --local-auth       Authenticate locally to target
   -d                 Get detailed information for users and groups, applies to -U, -G and -R
-  -k USERS           User(s) that exists on remote system (default: administrator,guest,krbtgt,domain admins,root,bin,none). Used to get sid with "lookupsids"
+  -k USERS           User(s) that exists on remote system (default: administrator,guest,krbtgt,domain admins,root,bin,none). Used to get SIDs with "lookupsids"
+  -kf USERS_FILE     File containing users to look for on remote system. Used to get users and SIDs with "lookupnames"
+  -bs BULK_SIZE      Defines bulk request size (default: 10)
   -r RANGES          RID ranges to enumerate (default: 500-550,1000-1050)
   -s SHARES_FILE     Brute force guessing for shares
   -t TIMEOUT         Sets connection timeout in seconds (default: 5s)
@@ -151,6 +153,7 @@ In addition, you will need the following Python packages:
 - ldap3
 - PyYaml
 - impacket
+- alive_progress
 
 For a faster processing of YAML (optional!) also install (should come as a dependency for PyYaml for most Linux distributions):
 - LibYAML
@@ -162,13 +165,15 @@ For all distribution examples below, LibYAML is already a dependency of the corr
 ##### ArchLinux
 
 ```console
-#  pacman -S smbclient python-ldap3 python-yaml impacket
+# pacman -S smbclient python-ldap3 python-yaml impacket
+# pip install alive_progress
 ```
 ##### Fedora/CentOS/RHEL
 (tested on Fedora Workstation 31)
 
 ```console
 # dnf install samba-common-tools samba-client python3-ldap3 python3-pyyaml python3-impacket
+# pip install alive_progress
 ```
 
 ##### Kali Linux/Debian/Ubuntu 
@@ -176,6 +181,7 @@ For all distribution examples below, LibYAML is already a dependency of the corr
 
 ```console
 # apt install smbclient python3-ldap3 python3-yaml python3-impacket
+# pip install alive_progress
 ```
 
 #### Linux distribution-agnostic
@@ -183,7 +189,7 @@ For all distribution examples below, LibYAML is already a dependency of the corr
 Depending on the Linux distribution either `pip3` or `pip` is needed:
 
 ```console
-$ pip install pyyaml ldap3 impacket
+$ pip install pyyaml ldap3 impacket alive_progress
 ```
 
 Alternative:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I made it for educational purposes for myself and to overcome issues with enum4l
 ## Differences
 Some things are implemented differently compared to the original enum4linux. These are the important differences:
 - RID cycling is not part of the default enumeration (```-A```) but can be enabled with ```-R```
+- RID cycling can be achieved faster, by grouping multiple SID lookups in the same rpcclient call
 - parameter naming is slightly different (e.g. ```-A``` instead of ```-a```)
 
 ## Credits
@@ -97,7 +98,7 @@ options:
   -O                 Get OS information via RPC
   -L                 Get additional domain info via LDAP/LDAPS (for DCs only)
   -I                 Get printer information via RPC
-  -R                 Enumerate users via RID cycling
+  -R                 Enumerate users via RID cycling. Optionally, specifies lookup request size.
   -N                 Do an NetBIOS names lookup (similar to nbtstat) and try to retrieve workgroup from output
   -w DOMAIN          Specify workgroup/domain manually (usually found automatically)
   -u USER            Specify username to use (default "")

--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -1747,7 +1747,7 @@ class EnumUsersRpc():
                     # Iterates over given wordlist
                     for line in f:
                         line_buff.append(line.strip())
-                        # Batch buffer filled 
+                        # Batch buffer filled
                         if len(line_buff) % self.bulk_size <= 0:
                             bar(len(line_buff))
                             users_ln = self.enum_from_lookupnames(line_buff)
@@ -2137,7 +2137,7 @@ class RidCycleParams:
     '''
     def __init__(self, rid_ranges, bulk_size, known_usernames, force_sid_enum):
         self.rid_ranges = rid_ranges
-        self.rid_count = sum(map(lambda r: (r[1]+1-r[0]), rid_ranges)) 
+        self.rid_count = sum(map(lambda r: (r[1]+1-r[0]), rid_ranges))
         self.bulk_size = bulk_size
         self.known_usernames = known_usernames.split(',')
         self.force_sid_enum = force_sid_enum
@@ -2172,7 +2172,7 @@ class RidCycling():
 
         # Expands known_usernames with found users from previous modules
         if output.get('users'):
-            map(lambda found_usr: self.cycle_params.known_usernames.append(found_usr), 
+            map(lambda found_usr: self.cycle_params.known_usernames.append(found_usr),
                 [usr_obj['username'] for _, usr_obj in output['users'].items()])
 
         sids_list = []
@@ -3229,12 +3229,12 @@ def process_impacket_smb_exception(exception, target):
 
 def merge_dicts(d1, d2, case_sens=False):
     '''
-    Merges dictionaries, reporting if any collision happens. 
+    Merges dictionaries, reporting if any collision happens.
     If `case_sens=True` is passed, dictionaries are treated as case insensitive and strings inside are flattened to lowercase.
     '''
     if not case_sens:
-        d1 = flatten_dict(d1)
-        d2 = flatten_dict(d2)
+        if d1: d1 = flatten_dict(d1)
+        if d2: d2 = flatten_dict(d2)
     if d1 is not None and d2 is not None:
         for com in set(d1.keys()).intersection(set(d2.keys())):
             if d1[com] != d2[com]:

--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -1743,7 +1743,7 @@ class EnumUsersRpc():
                     pass
                 f.seek(0)
                 #with alive_bar(ceil(file_lines/self.batch_size)) as bar:
-                with alive_bar(file_lines+1) as bar:
+                with alive_bar(file_lines+1, enrich_print=False, theme='classic') as bar:
                     pos = 0
                     line_buff = []
                     users_ln_output = dict()
@@ -2287,7 +2287,7 @@ class RidCycling():
         '''
         Takes a SID as first parameter well as list of RID ranges (as tuples) as second parameter and does RID cycling.
         '''
-        with alive_bar(self.cycle_params.rid_count) as bar:
+        with alive_bar(self.cycle_params.rid_count, enrich_print=False, theme='classic') as bar:
             for rid_range in rid_ranges:
                 (start_rid, end_rid) = rid_range
 

--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -3331,7 +3331,7 @@ def check_arguments():
     parser.add_argument("-kf", dest="usernames_file", type=str, help="""
             File containing users to look for on remote system.\n
             Used to get users and SIDs with \"lookupnames\".\n""")
-    parser.add_argument("-bs", dest="bulk_size", type=int, default=BULK_SIZE, help=f"Defines bulk request size. Default: {BULK_SIZE}")
+    parser.add_argument("-bs", dest="bulk_size", type=int, default=BULK_SIZE, help=f"Defines bulk request size (default: {BULK_SIZE})")
     parser.add_argument("--force-sid-enum", dest="force_sid_enum", action="store_true", help="Forces SID enumeration to run even if Domain SID is found.")
     parser.add_argument("-r", dest="ranges", default=RID_RANGES, type=str, help=f"RID ranges to enumerate (default: {RID_RANGES})")
     parser.add_argument("-s", dest="shares_file", help="Brute force guessing for shares")

--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -516,8 +516,8 @@ class SambaTool():
             self.exec += ['-s', f'{target.samba_config.get_path()}']
 
         # This enables debugging output (level 1) for the Samba client tools. The problem is that the
-        # tools often throw misleading error codes like NT_STATUS_CONNECTION_DISCONNECTED. Often this 
-        # error is associated with SMB dialect incompatibilities between client and server. But this 
+        # tools often throw misleading error codes like NT_STATUS_CONNECTION_DISCONNECTED. Often this
+        # error is associated with SMB dialect incompatibilities between client and server. But this
         # error also occurs on other occasions. In order to find out the real reason we need to fetch
         # earlier errors which this debugging level will provide.
         #self.exec += ['-d1']
@@ -981,7 +981,7 @@ class EnumSmb():
 
         # Does the target only support one dialect? Then this must be also the preferred dialect.
         preferred_dialect = None
-        if sum(1 for value in supported.values() if value == True) == 1:
+        if sum(1 for value in supported.values() if value is True) == 1:
             if last_supported_dialect == SMB_DIALECT:
                 output["SMB1 only"] = True
                 self.target.smb1_only = True
@@ -1312,16 +1312,16 @@ class EnumSmbDomainInfo():
         # mean that the 'NetBIOS domain name' is the same as the machine's workgroup. Therefore, we set the domain
         # to the 'NetBIOS computer name' which will enforce local authentication.
 
-        if (smb_domain_info["NetBIOS computer name"] and 
-                smb_domain_info["NetBIOS domain name"] and 
+        if (smb_domain_info["NetBIOS computer name"] and
+                smb_domain_info["NetBIOS domain name"] and
                 smb_domain_info["DNS domain"] and
-                smb_domain_info["FQDN"] and 
-                smb_domain_info["DNS domain"] in smb_domain_info["FQDN"] and 
+                smb_domain_info["FQDN"] and
+                smb_domain_info["DNS domain"] in smb_domain_info["FQDN"] and
                 '.' in smb_domain_info["FQDN"]):
 
             smb_domain_info["Derived domain"] = smb_domain_info["NetBIOS domain name"]
             smb_domain_info["Derived membership"] = "domain member"
- 
+
             if not self.creds.local_auth:
                 self.creds.set_domain(smb_domain_info["NetBIOS domain name"])
         elif (smb_domain_info["NetBIOS domain name"] and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 impacket>=0.9.21
 ldap3
 PyYAML>=5.1
+alive_progress>=2.4

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ shutil.copyfile('enum4linux-ng.py', 'enum4linux-ng')
 
 setup(
     name='enum4linux-ng',
-    version='1.1.0',
+    version='1.2.0',
     author='mw',
     description='A next generation version of enum4linux',
     long_description=long_description,


### PR DESCRIPTION
Full changelog:
- Restores `-R` to just a flag to enable RID Cycling
- Adds dedicated `-bs` to define bulk_size 
- Bulk mode is now used also in lookupnames 
- Adds username bruteforcing in 'User via RPC' phase (f_ound usenames are added to dictionary and therefore passed to following stages._)
- SID gathering phase now tries to gather SIDs using found usernames from previous stages (_known-users list is extended with found usernames_)  
- Adds `--force-enum-sid` flag to force SID enumeration even if Domain SID is found
- Adds dedicated `merge_dict` function
- Adds collising check and report when merging dictionaries (_can happen when RID from differend SID prefix are found_)

Hope you find it useful, feel free to change anything that does not suit your coding style! 