### PR TITLE
Show error when getting timeout during share enumeration

### DIFF
--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -2449,6 +2449,9 @@ class EnumShares():
 
         result = SambaSmbclient(['dir', f'{share}'], self.target, self.creds).run(log=f'Attempting to map share //{self.target.host}/{share}', error_filter=False)
 
+        if not result.retval:
+            return Result(None, f"Could not check share: {result.retmsg}")
+
         if "NT_STATUS_BAD_NETWORK_NAME" in result.retmsg:
             return Result(None, "Share doesn't exist")
 
@@ -2473,6 +2476,9 @@ class EnumShares():
 
         if "NT_STATUS_INVALID_PARAMETER" in result.retmsg:
             return Result(None, "Could not check share: STATUS_INVALID_PARAMETER")
+
+        if "NT_STATUS_IO_TIMEOUT" in result.retmsg:
+            return Result(None, "Could not check share: STATUS_IO_TIMEOUT")
 
         if re.search(r"\n\s+\.\.\s+D.*\d{4}\n", result.retmsg) or re.search(r".*blocks\sof\ssize.*blocks\savailable.*", result.retmsg):
             return Result({"mapping":"ok", "listing":"ok"}, "Mapping: OK, Listing: OK")


### PR DESCRIPTION
Under bad network conditions, or when the server is too slow, it may happen that smbclient runs into a timeout. Currently, this leads to the message "Could not parse result of smbclient command, please open a GitHub issue".

This PR changes this to return a proper error message: "Could not check share: STATUS_IO_TIMEOUT".

This is what I see when running smbclient manually:

```console
$ smbclient -W domain -U user%pass -s /tmp/tmp6opu33mz -t 5 -c dir //10.10.11.236/NETLOGON
do_connect: Connection to 10.10.11.236 failed (Error NT_STATUS_IO_TIMEOUT)
```

Note that a comparison similar to the others (`if "NT_STATUS_IO_TIMEOUT" in result.retmsg`) did not work, because for some reason, `result.retmsg` is just "timed out" instead of the NT_ code. So I check for string equality here.