### PR TITLE
fix wrong var returned NO_COLOR logic 

### DIFF
--- a/enum4linux-ng.py
+++ b/enum4linux-ng.py
@@ -332,7 +332,7 @@ class Colors(Enum):
     def __call__(self, message):
         if GLOBAL_COLORS:
             return f"{self.value}{message}\033[0m"
-        return msg
+        return message
 
 class Result:
     '''


### PR DESCRIPTION
closes #57 

**CHANGES**
It previously tried to return a non existing variable `msg` when NO_COLOR was given.
Now changed to the intended `message` varaible

**NOTE**
I have not tested this beyond running the program with and without `NO_COLOR`

(For clarity I also opened the issue, just on the wrong account)